### PR TITLE
Fixed postProcessHtml option

### DIFF
--- a/es6/index.js
+++ b/es6/index.js
@@ -38,13 +38,8 @@ PrerendererWebpackPlugin.prototype.apply = function (compiler) {
       return PrerendererInstance.renderRoutes(this._options.routes || [])
     })
     .then(renderedRoutes => {
-      const {route, html} = renderedRoutes
-
       if (this._options.postProcessHtml) {
-        renderedRoutes.html = this._options.postProcessHtml({
-          html,
-          route
-        })
+        renderedRoutes = this._options.postProcessHtml(renderedRoutes)
       }
 
       return renderedRoutes

--- a/es6/index.js
+++ b/es6/index.js
@@ -38,11 +38,7 @@ PrerendererWebpackPlugin.prototype.apply = function (compiler) {
       return PrerendererInstance.renderRoutes(this._options.routes || [])
     })
     .then(renderedRoutes => {
-      if (this._options.postProcessHtml) {
-        renderedRoutes = this._options.postProcessHtml(renderedRoutes)
-      }
-
-      return renderedRoutes
+      return this._options.postProcessHtml ? this._options.postProcessHtml(renderedRoutes) : renderedRoutes
     })
     .then(processedRoutes => {
       const promises = Promise.all(processedRoutes.map(processedRoute => {


### PR DESCRIPTION
Current usage of postProcessHtml option incorrectly assigns renderedRoutes.html to the output of this._options.postProcessHtml(). However, renderedRoutes is an array of route objects with both route and html properties, so the assignment of renderedRoutes.html doesn't make sense here. This proposed change allows users to pass a function as the postProcessHtml option in the webpack plugin. This function is responsible for processing the array of route objects and returning it as a similar array, processedRoutes, to be used in the next .then() statement on line 47. 

As an afterthought, it may be better to use "processedRoutes" for the variable assignment inside the if statement on line 42 and return that variable on line 45 instead of mutating the "renderedRoutes" variable. 