### PR TITLE
Change package name prerenderer -> @prerenderer/prerenderer

### DIFF
--- a/es5-autogenerated/index.js
+++ b/es5-autogenerated/index.js
@@ -3,7 +3,7 @@
 var fs = require('fs');
 var path = require('path');
 var mkdirp = require('mkdirp-promise');
-var Prerenderer = require('prerenderer');
+var Prerenderer = require('@prerenderer/prerenderer');
 
 function PrerendererWebpackPlugin() {
   var _this = this;

--- a/es6/index.js
+++ b/es6/index.js
@@ -1,7 +1,7 @@
 const fs = require('fs')
 const path = require('path')
 const mkdirp = require('mkdirp-promise')
-const Prerenderer = require('prerenderer')
+const Prerenderer = require('@prerenderer/prerenderer')
 
 function PrerendererWebpackPlugin (...args) {
   // Normal args object.


### PR DESCRIPTION
Prerenderer (starting from version 0.6.0) has moved to the npm organization @prerenderer.